### PR TITLE
Use ctest as test launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,8 +149,8 @@ script:
   # pytest
   set -ex
   if [ "$SONAR" != true ]; then
-    cd tests
-    PYTHONPATH=../build/tests ${PY_CMD} -m pytest
+    cd build
+    ctest -V
   fi
   set +ex
 after_failure: cat tests/test_cmake_build/*.log*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ IF (BUILD_TESTS OR BUILD_EXAMPLES)
     target_include_directories(armadillo INTERFACE ${ARMADILLO_INCLUDE_DIR})
 
     add_subdirectory(third_party/pybind11)
+
+
+    ENABLE_TESTING()
+    FIND_PACKAGE(Python3)
 ENDIF()
 
 IF(BUILD_TESTS)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,3 +36,12 @@ TARGET_COMPILE_DEFINITIONS(${MODNAME}
 INSTALL(TARGETS ${MODNAME} DESTINATION examples)
 FILE(GLOB PY_TEST_FILES "${PROJECT_SOURCE_DIR}/examples/*.py")
 INSTALL(FILES ${PY_TEST_FILES} DESTINATION examples)
+
+# ##############################################################################
+#                                  EXAMPLES                                    #
+# ##############################################################################
+ADD_TEST(NAME example
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ${Python3_EXECUTABLE} carma_examples.py)
+SET_PROPERTY(TEST example
+        PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,3 +38,12 @@ TARGET_COMPILE_DEFINITIONS(${MODNAME}
 INSTALL(TARGETS ${MODNAME} DESTINATION tests)
 FILE(GLOB PY_TEST_FILES "${PROJECT_SOURCE_DIR}/tests/*.py")
 INSTALL(FILES ${PY_TEST_FILES} DESTINATION tests)
+
+# ##############################################################################
+#                                    TESTS                                     #
+# ##############################################################################
+ADD_TEST(NAME pytest
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+         COMMAND ${Python3_EXECUTABLE} -m pytest)
+SET_PROPERTY(TEST pytest 
+             PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
About  issue #25.

By the way, if examples are also compiled (using `-DBUILD_EXAMPLES`), they are also run using `ctest`.