### PR TITLE
Add clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+---
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+# customized using https://zed0.co.uk/clang-format-configurator/
+---
+BasedOnStyle: Chromium
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakTemplateDeclarations: 'Yes'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBinaryOperators: All
+BreakInheritanceList: BeforeComma
+ColumnLimit: '120'
+CompactNamespaces: 'false'
+FixNamespaceComments: 'true'
+IndentWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+AlignAfterOpenBracket: AlwaysBreak
+IndentCaseLabels: true
+AllowAllParametersOfDeclarationOnNextLine: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,3 +89,39 @@ ENDIF()
 IF(BUILD_EXAMPLES)
     add_subdirectory(examples)
 ENDIF()
+
+#------------------------------------------------------
+
+# search for clang-format and add target
+find_program(CLANG_FORMAT clang-format)
+if (CLANG_FORMAT)
+    exec_program(${CLANG_FORMAT} ARGS -version
+            OUTPUT_VARIABLE CLANG_FORMAT_RAW_VERSION)
+    string(REGEX MATCH "[1-9][0-9]*\.[0-9]+\.[0-9]+"
+            CLANG_FORMAT_VERSION ${CLANG_FORMAT_RAW_VERSION})
+    if (CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "6.0.0") 
+        add_custom_target(clang-format
+                COMMAND echo "running ${CLANG_FORMAT} ..."
+                COMMAND ${CMAKE_COMMAND}
+                -DPROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+                -DCLANG_FORMAT="${CLANG_FORMAT}"
+                -P ${PROJECT_SOURCE_DIR}/cmake/ClangFormatProcess.cmake)
+        message(STATUS "clang-format target for updating code format is available")
+    else()
+        message(WARNING "incompatible clang-format found (<6.0.0); clang-format target is not available.")
+        add_custom_target(clang-format
+                COMMAND ${CMAKE_COMMAND} -E echo ""
+                COMMAND ${CMAKE_COMMAND} -E echo "*** code formatting not available since clang-format version is incompatible ***"
+                COMMAND ${CMAKE_COMMAND} -E echo ""
+                COMMENT "Inform about not available code format."
+                )
+    endif()
+else ()
+    message(WARNING "clang-format no found; clang-format target is not available.")
+    add_custom_target(clang-format
+            COMMAND ${CMAKE_COMMAND} -E echo ""
+            COMMAND ${CMAKE_COMMAND} -E echo "*** code formatting not available since clang-format has not been found ***"
+            COMMAND ${CMAKE_COMMAND} -E echo ""
+            COMMENT "Inform about not available code format."
+            )
+endif ()

--- a/cmake/ClangFormatProcess.cmake
+++ b/cmake/ClangFormatProcess.cmake
@@ -1,0 +1,17 @@
+# --------------- runs clang-format in place using the style file ---------------
+
+if(PROJECT_SOURCE_DIR AND CLANG_FORMAT)
+    # get C++ sources file list (ignoring packages)
+    file(GLOB_RECURSE ALL_SOURCE_FILES
+            ${PROJECT_SOURCE_DIR}/include/**.h
+            ${PROJECT_SOURCE_DIR}/tests/src/**.cpp
+            ${PROJECT_SOURCE_DIR}/tests/src/**.h
+            ${PROJECT_SOURCE_DIR}/examples/src/**.cpp
+            ${PROJECT_SOURCE_DIR}/examples/src/**.h
+            )
+
+    # apply style to the file list
+    foreach(SOURCE_FILE ${ALL_SOURCE_FILES})
+        execute_process(COMMAND "${CLANG_FORMAT}" -style=file -verbose -i "${SOURCE_FILE}")
+    endforeach()
+endif()


### PR DESCRIPTION
Before merging, clang-format style has to be defined (cf #34 )

This adds a new CMake target named `clang-format` which can be used to reformat all sources files (locations defined in `cmake/ClangFormatProcess.cmake`)