### PR TITLE
Add coverage report

### DIFF
--- a/.travis-ci/after_success.sh
+++ b/.travis-ci/after_success.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [[ "$DEBUG_CI" == "true" ]]; then
+  set -x
+fi
+
+if [[ "$COVERAGE" == "true" ]]; then
+    cd "${TRAVIS_BUILD_DIR}"/build
+    lcov --list coverage.info
+    coveralls-lcov coverage.info
+fi

--- a/.travis-ci/configure.sh
+++ b/.travis-ci/configure.sh
@@ -7,6 +7,7 @@ CMAKE_EXTRA_ARGS+=" -DBUILD_TESTS=ON"
 if [ -n "$CPP" ]; then CPPSTD=-std=c++$CPP; fi
 if [ "$NOWND" = true ]; then CMAKE_EXTRA_ARGS+=" -DCARMA_DONT_REQUIRE_OWNDATA"; fi 
 if [ "$VALGRIND" = true ]; then CMAKE_EXTRA_ARGS+=" -DVALGRIND_TEST_WRAPPER=on"; fi 
+if [ "$COVERAGE" = true ]; then CMAKE_EXTRA_ARGS+=" -DENABLE_COVERAGE=on"; fi
 
 case $TRAVIS_OS_NAME in
   linux|osx)

--- a/.travis-ci/install.sh
+++ b/.travis-ci/install.sh
@@ -13,6 +13,10 @@ case $TRAVIS_OS_NAME in
     ;;
 esac
 
+if [[ "$COVERAGE" == "true" ]]; then
+    gem install coveralls-lcov
+fi
+
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 ${PY_CMD} get-pip.py # or use apt-get install python3-pip
 ${PY_CMD} -m pip install --progress-bar off pip --upgrade

--- a/.travis-ci/make_and_run.sh
+++ b/.travis-ci/make_and_run.sh
@@ -21,4 +21,9 @@ ${TRAVIS_BUILD_DIR}/.travis-ci/configure.sh
 cd build
 
 cmake --build . --target ${TARGET} --config ${CMAKE_BUILD_TYPE}
-ctest -C ${CMAKE_BUILD_TYPE} -V
+
+if [[ "$COVERAGE" == "true" ]]; then
+  cmake --build . --target coverage --config ${CMAKE_BUILD_TYPE}
+else
+  ctest -C ${CMAKE_BUILD_TYPE} -V
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,18 @@ matrix:
           - g++-7
           - python3.7-dev
           - python3.7-venv
+  - os: linux
+    dist: bionic
+    env: PYTHON_VERSION=3.7 CPP=14 COMPILER=gcc-7 DEBUG=true COVERAGE=true
+    name: Python 3.7, c++14, gcc 7 Coverage
+    addons:
+      apt:
+        packages:
+          - g++-7
+          - python3.7-dev
+          - python3.7-venv
+          - lcov
+          # also required in the standard ubuntu:bionic: gcc, make
   - os: osx
     osx_image: xcode11.5
     env: PYTHON_VERSION=3.7 CPP=14 COMPILER=clang
@@ -134,3 +146,6 @@ script:
 
 after_failure: 
   - cat tests/test_cmake_build/*.log*
+
+after_success:
+  - ${TRAVIS_BUILD_DIR}/.travis-ci/after_success.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,14 @@ endif ()
 SET(PROJECT_RELEASE_DEFINITIONS ARMA_NO_DEBUG)
 # see linkg for a more expensive approach https://github.com/VcDevel/Vc/blob/master/cmake/OptimizeForArchitecture.cmake
 
+if (ENABLE_COVERAGE)
+# --coverage option is used to compile and link code instrumented for coverage analysis.
+# The option is a synonym for -fprofile-arcs -ftest-coverage (when compiling) and -lgcov (when linking).
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+endif()
 
 ADD_LIBRARY(carma INTERFACE)
 TARGET_LINK_LIBRARIES(carma INTERFACE pybind11 armadillo)
@@ -154,3 +162,72 @@ if(NOT DEFINED CARMA_DEV_TARGET OR CARMA_DEV_TARGET)
                 )
     endif ()
 endif()
+
+#------------------------------------------------------
+
+# unit tests coverage
+
+if (ENABLE_COVERAGE)
+    find_program(LCOV lcov)
+    if (NOT LCOV)
+        message(FATAL_ERROR "lcov not found, cannot perform coverage.")
+    endif ()
+
+    # coveralls.io does not support striped paths
+    #find_program (SED NAMES sed)
+    #if (NOT SED)
+    #    message(FATAL_ERROR "Unable to find sed")
+    #else()
+    #    # message(STATUS "sed found at ${SED}")
+    #endif (NOT SED)
+
+    # Don't forget '' around each pattern
+    set(LCOV_EXCLUDE_PATTERN "'${PROJECT_SOURCE_DIR}/third_party/*'")
+
+    add_custom_target(coverage
+            # Cleanup previously generated profiling data
+            COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --zerocounters
+            # Initialize profiling data with zero coverage for every instrumented line of the project
+            # This way the percentage of total lines covered will always be correct, even when not all source code files were loaded during the test(s)
+            COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --capture --initial --output-file coverage_base.info
+            # Run tests
+            COMMAND ${CMAKE_CTEST_COMMAND} -j ${PROCESSOR_COUNT}
+            # Collect data from executions
+            COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --capture --output-file coverage_ctest.info
+            # Combine base and ctest results
+            COMMAND ${LCOV} --add-tracefile coverage_base.info --add-tracefile coverage_ctest.info --output-file coverage_full.info
+            # Extract only project data (--no-capture or --remove options may be used to select collected data)
+            COMMAND ${LCOV} --remove coverage_full.info ${LCOV_EXCLUDE_PATTERN} --output-file coverage_filtered.info
+            COMMAND ${LCOV} --extract coverage_filtered.info '${PROJECT_SOURCE_DIR}/*' --output-file coverage.info
+            # coveralls.io does not support striped paths
+            #COMMAND ${SED} -i.bak 's|SF:${PROJECT_SOURCE_DIR}/|SF:|g' coverage.info
+            DEPENDS tests
+            COMMENT "Running test coverage."
+            WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+            )
+    message(STATUS "coverage target for code coverage is available")
+    
+    find_program(GENHTML genhtml)
+    if (NOT GENHTML)
+        message(WARNING "genhtml not found, cannot perform report-coverage.")
+    else ()
+        add_custom_target(coverage-report
+                COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/coverage"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/coverage"
+                COMMAND ${GENHTML} -o coverage -t "${CMAKE_PROJECT_NAME} test coverage" --ignore-errors source --legend --num-spaces 4 coverage.info
+                COMMAND ${LCOV} --list coverage.info
+                DEPENDS coverage
+                COMMENT "Building coverage html report."
+                WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+                )
+    endif ()
+else ()
+    add_custom_target(coverage
+            COMMAND ${CMAKE_COMMAND} -E echo ""
+            COMMAND ${CMAKE_COMMAND} -E echo "*** Use CMAKE_BUILD_TYPE=Coverage option in cmake configuration to enable code coverage ***"
+            COMMAND ${CMAKE_COMMAND} -E echo ""
+            COMMENT "Inform about not available code coverage."
+            )
+    add_custom_target(coverage-report DEPENDS coverage)
+endif ()
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
   <a href="https://travis-ci.com/RUrlus/carma">
     <img src="https://img.shields.io/travis/rurlus/carma.svg?style=for-the-badge" alt="Build Status"/>
   </a>
+  <!-- Coverage status -->
+  <a href="https://coveralls.io/github/hpwxf/carma?branch=master">
+    <img src="https://img.shields.io/coveralls/gitHub/hpwxf/carma?style=for-the-badge" alt="Coveralls github" >
+  </a>
   <!-- Documentation status -->
   <a href="https://carma.readthedocs.io/en/latest/?badge=latest">
     <img src="https://readthedocs.org/projects/carma/badge/?version=latest&style=for-the-badge" alt="Documentation Status" />

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
     <img src="https://img.shields.io/travis/rurlus/carma.svg?style=for-the-badge" alt="Build Status"/>
   </a>
   <!-- Coverage status -->
-  <a href="https://coveralls.io/github/hpwxf/carma?branch=master">
-    <img src="https://img.shields.io/coveralls/gitHub/hpwxf/carma?style=for-the-badge" alt="Coveralls github" >
+  <a href="https://coveralls.io/github/RUrlus/carma?branch=master">
+    <img src="https://img.shields.io/coveralls/gitHub/RUrlus/carma?style=for-the-badge" alt="Coveralls github" >
   </a>
   <!-- Documentation status -->
   <a href="https://carma.readthedocs.io/en/latest/?badge=latest">


### PR DESCRIPTION
Coverage report uses `lcov` for the analysis and coveralls.io as repository.

A demo is available https://coveralls.io/github/hpwxf/carma.

The embedded badge (in README.md) will be ok after the merge of this PR  in master.

Closes #31 