### PR TITLE
Move coverage target as a dev target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,73 +161,71 @@ if(NOT DEFINED CARMA_DEV_TARGET OR CARMA_DEV_TARGET)
                 COMMENT "Inform about not available code format."
                 )
     endif ()
-endif()
 
-#------------------------------------------------------
+    #------------------------------------------------------
+    # unit tests coverage
 
-# unit tests coverage
-
-if (ENABLE_COVERAGE)
-    find_program(LCOV lcov)
-    if (NOT LCOV)
-        message(FATAL_ERROR "lcov not found, cannot perform coverage.")
-    endif ()
-
-    # coveralls.io does not support striped paths
-    #find_program (SED NAMES sed)
-    #if (NOT SED)
-    #    message(FATAL_ERROR "Unable to find sed")
-    #else()
-    #    # message(STATUS "sed found at ${SED}")
-    #endif (NOT SED)
-
-    # Don't forget '' around each pattern
-    set(LCOV_EXCLUDE_PATTERN "'${PROJECT_SOURCE_DIR}/third_party/*'")
-
-    add_custom_target(coverage
-            # Cleanup previously generated profiling data
-            COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --zerocounters
-            # Initialize profiling data with zero coverage for every instrumented line of the project
-            # This way the percentage of total lines covered will always be correct, even when not all source code files were loaded during the test(s)
-            COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --capture --initial --output-file coverage_base.info
-            # Run tests
-            COMMAND ${CMAKE_CTEST_COMMAND} -j ${PROCESSOR_COUNT}
-            # Collect data from executions
-            COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --capture --output-file coverage_ctest.info
-            # Combine base and ctest results
-            COMMAND ${LCOV} --add-tracefile coverage_base.info --add-tracefile coverage_ctest.info --output-file coverage_full.info
-            # Extract only project data (--no-capture or --remove options may be used to select collected data)
-            COMMAND ${LCOV} --remove coverage_full.info ${LCOV_EXCLUDE_PATTERN} --output-file coverage_filtered.info
-            COMMAND ${LCOV} --extract coverage_filtered.info '${PROJECT_SOURCE_DIR}/*' --output-file coverage.info
-            # coveralls.io does not support striped paths
-            #COMMAND ${SED} -i.bak 's|SF:${PROJECT_SOURCE_DIR}/|SF:|g' coverage.info
-            DEPENDS tests
-            COMMENT "Running test coverage."
-            WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
-            )
-    message(STATUS "coverage target for code coverage is available")
+    if (ENABLE_COVERAGE)
+        find_program(LCOV lcov)
+        if (NOT LCOV)
+            message(FATAL_ERROR "lcov not found, cannot perform coverage.")
+        endif ()
     
-    find_program(GENHTML genhtml)
-    if (NOT GENHTML)
-        message(WARNING "genhtml not found, cannot perform report-coverage.")
-    else ()
-        add_custom_target(coverage-report
-                COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/coverage"
-                COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/coverage"
-                COMMAND ${GENHTML} -o coverage -t "${CMAKE_PROJECT_NAME} test coverage" --ignore-errors source --legend --num-spaces 4 coverage.info
-                COMMAND ${LCOV} --list coverage.info
-                DEPENDS coverage
-                COMMENT "Building coverage html report."
+        # coveralls.io does not support striped paths
+        #find_program (SED NAMES sed)
+        #if (NOT SED)
+        #    message(FATAL_ERROR "Unable to find sed")
+        #else()
+        #    # message(STATUS "sed found at ${SED}")
+        #endif (NOT SED)
+    
+        # Don't forget '' around each pattern
+        set(LCOV_EXCLUDE_PATTERN "'${PROJECT_SOURCE_DIR}/third_party/*'")
+    
+        add_custom_target(coverage
+                # Cleanup previously generated profiling data
+                COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --zerocounters
+                # Initialize profiling data with zero coverage for every instrumented line of the project
+                # This way the percentage of total lines covered will always be correct, even when not all source code files were loaded during the test(s)
+                COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --capture --initial --output-file coverage_base.info
+                # Run tests
+                COMMAND ${CMAKE_CTEST_COMMAND} -j ${PROCESSOR_COUNT}
+                # Collect data from executions
+                COMMAND ${LCOV} --base-directory ${PROJECT_SOURCE_DIR} --directory ${PROJECT_BINARY_DIR} --capture --output-file coverage_ctest.info
+                # Combine base and ctest results
+                COMMAND ${LCOV} --add-tracefile coverage_base.info --add-tracefile coverage_ctest.info --output-file coverage_full.info
+                # Extract only project data (--no-capture or --remove options may be used to select collected data)
+                COMMAND ${LCOV} --remove coverage_full.info ${LCOV_EXCLUDE_PATTERN} --output-file coverage_filtered.info
+                COMMAND ${LCOV} --extract coverage_filtered.info '${PROJECT_SOURCE_DIR}/*' --output-file coverage.info
+                # coveralls.io does not support striped paths
+                #COMMAND ${SED} -i.bak 's|SF:${PROJECT_SOURCE_DIR}/|SF:|g' coverage.info
+                DEPENDS tests
+                COMMENT "Running test coverage."
                 WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
                 )
+        message(STATUS "coverage target for code coverage is available")
+        
+        find_program(GENHTML genhtml)
+        if (NOT GENHTML)
+            message(WARNING "genhtml not found, cannot perform report-coverage.")
+        else ()
+            add_custom_target(coverage-report
+                    COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/coverage"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/coverage"
+                    COMMAND ${GENHTML} -o coverage -t "${CMAKE_PROJECT_NAME} test coverage" --ignore-errors source --legend --num-spaces 4 coverage.info
+                    COMMAND ${LCOV} --list coverage.info
+                    DEPENDS coverage
+                    COMMENT "Building coverage html report."
+                    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+                    )
+        endif ()
+    else ()
+        add_custom_target(coverage
+                COMMAND ${CMAKE_COMMAND} -E echo ""
+                COMMAND ${CMAKE_COMMAND} -E echo "*** Use CMAKE_BUILD_TYPE=Coverage option in cmake configuration to enable code coverage ***"
+                COMMAND ${CMAKE_COMMAND} -E echo ""
+                COMMENT "Inform about not available code coverage."
+                )
+        add_custom_target(coverage-report DEPENDS coverage)
     endif ()
-else ()
-    add_custom_target(coverage
-            COMMAND ${CMAKE_COMMAND} -E echo ""
-            COMMAND ${CMAKE_COMMAND} -E echo "*** Use CMAKE_BUILD_TYPE=Coverage option in cmake configuration to enable code coverage ***"
-            COMMAND ${CMAKE_COMMAND} -E echo ""
-            COMMENT "Inform about not available code coverage."
-            )
-    add_custom_target(coverage-report DEPENDS coverage)
-endif ()
-
+endif()


### PR DESCRIPTION
This allows to avoid conflict with the target with the same name (aka `coverage` is that case) when carma is used as a CMake sub-project.

The change is *only* the move of the `endif` of the following condition to the end (after coverage block)
```
if(NOT DEFINED CARMA_DEV_TARGET OR CARMA_DEV_TARGET)
```