### PR TITLE
CHG: remove deprecated namespace macro from Pybind11

### DIFF
--- a/include/carma/carma/converters.h
+++ b/include/carma/carma/converters.h
@@ -539,8 +539,8 @@ inline py::array_t<T> to_numpy(arma::Cube<T>&& src, bool copy = true) {
 
 }  // namespace carma
 
-NAMESPACE_BEGIN(pybind11)
-NAMESPACE_BEGIN(detail)
+namespace pybind11 {
+namespace detail {
 
 template <typename armaT>
 struct type_caster<armaT, enable_if_t<carma::is_convertible<armaT>::value>> {
@@ -628,6 +628,6 @@ struct type_caster<armaT, enable_if_t<carma::is_convertible<armaT>::value>> {
 
     PYBIND11_TYPE_CASTER(armaT, _("Numpy.ndarray[") + npy_format_descriptor<T>::name + _("]"));
 };
-NAMESPACE_END(detail)
-NAMESPACE_END(pybind11)
+} /* namespace detail */
+} /* namespace pybind11 */
 #endif /* ARMA_CONVERTERS */


### PR DESCRIPTION
Fixes issue with newer versions of Pybind11 where the namespace macro changed.

Closes #60 