### PR TITLE
Submodule change since Armadillo branch 9.800.x does not exist anymore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/armadillo-code"]
 	path = third_party/armadillo-code
 	url = https://gitlab.com/conradsnicta/armadillo-code.git
-	branch = 9.800.x
+	branch = old-9.800.x
 [submodule "third_party/pybind11"]
 	path = third_party/pybind11
 	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
Armadillo submodule branch `9.800.x` does not exist anymore. Changed to branch `old-9.800.x` instead. 

Not having the correct branch causes issues with having _carma_ as a submobule since `git submodule --init --recursive --remote` will throw an error. 