### PR TITLE
fix includes; fix version check

### DIFF
--- a/include/carma
+++ b/include/carma
@@ -15,7 +15,7 @@
   #if defined(ARMA_VERSION_MAJOR)
     #error "carma: please include the armadillo header after the carma header or use the CARMA CMake build"
   #endif
-  #include <cnalloc.hpp>
+  #include "carma_bits/cnalloc.hpp"
 #endif
 
 #ifndef ARMA_VERSION_MAJOR

--- a/include/carma
+++ b/include/carma
@@ -29,7 +29,7 @@
 #endif
 
 #define CARMA_ARMA_VERSION (ARMA_VERSION_MAJOR * 10000 + ARMA_VERSION_MINOR * 100 + ARMA_VERSION_PATCH)
-#if (CARMA_ARMA_VERSION < 100501)
+#if (CARMA_ARMA_VERSION < 100502)
   #error "carma: minimum supported armadillo version is 10.5.2"
 #endif
 

--- a/include/carma
+++ b/include/carma
@@ -18,9 +18,7 @@
   #include "carma_bits/cnalloc.hpp"
 #endif
 
-#ifndef ARMA_VERSION_MAJOR
-  #include <armadillo>
-#endif
+#include <armadillo>
 
 #if defined(CARMA_ARMA_ALIEN_MEM_FUNCTIONS_SET)
   #if (defined(ARMA_ALIEN_MEM_ALLOC_FUNCTION) && !defined(ARMA_ALIEN_MEM_FREE_FUNCTION)) || (!defined(ARMA_ALIEN_MEM_ALLOC_FUNCTION) && defined(ARMA_ALIEN_MEM_FREE_FUNCTION))


### PR DESCRIPTION
Changes:
- fix for https://github.com/RUrlus/carma/issues/79 (changes `#include <cnalloc.hpp>` to `#include "carma_bits/cnalloc.hpp"`)
- fix armadillo version check (check for armadillo 10.5.2 instead of 10.5.1)
- remove include guard that's not necessary

