### PR TITLE
Prevent useless link with pythonXX_d.lib in Debug mode

### DIFF
--- a/include/carma_bits/cnalloc.h
+++ b/include/carma_bits/cnalloc.h
@@ -1,6 +1,10 @@
 #ifndef INCLUDE_CARMA_BITS_CNALLOC_H_
 #define INCLUDE_CARMA_BITS_CNALLOC_H_
 
+// pybind11 include required even if not explicitly used 
+// to prevent link with pythonXX_d.lib on Win32 
+// (cf Py_DEBUG defined in numpy headers and https://github.com/pybind/pybind11/issues/1295)
+#include <pybind11/pybind11.h>     
 #define NPY_NO_DEPRECATED_API NPY_1_14_API_VERSION
 #include <numpy/arrayobject.h>
 #include <numpy/ndarraytypes.h>


### PR DESCRIPTION
```
LINK : fatal error LNK1104: cannot open file 'python39_d.lib'
```
On Windows, when CMAKE_BUILD_TYPE was Debug, I had a configuration where the linker looked for pythonXX_d.lib instead of pythonXX.lib.

Usually, pybind11 prevents that (as shown here: https://github.com/pybind/pybind11/issues/1295).
Unfornutaly in ncalloc.h, there are NumPy includes but not the pybind11 include which manages that.

That's why I suggest adding pybind11 include before NumPy includes to prevent that.
(debug python lib is not commonly installed and if debug lib is wanted, using Py_DEBUG directive will help)