### PR TITLE
Changed non-existent `n_alloc` attribute of matrix to `n_elem`

### DIFF
--- a/include/carma_bits/numpytoarma.h
+++ b/include/carma_bits/numpytoarma.h
@@ -130,7 +130,7 @@ inline arma::Mat<T> arr_to_mat(
     // we have stolen, numpy no longer owns the memory and
     // we haven't copied into the matrix hence Arma has to manage the lifetime
     // of the memory
-    arma::access::rw(dest.n_alloc) = nelem;
+    arma::access::rw(dest.n_elem) = nelem;
     arma::access::rw(dest.mem_state) = 0;
     return dest;
 } /* arr_to_mat */


### PR DESCRIPTION
When trying to install another library that makes use of CARMA, I got an error that class arma::Mat<float> does not have a member called `n_alloc`, so I changed it to `n_elem` which was the most similar attribute that I found in the documentation. After this change, the installation worked.