### PR TITLE
change default armadillo gitlab branch to 11.1.x

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        armadillo: ["10.6.x", "10.8.x", "11.0.x"]
+        armadillo: ["10.6.x", "10.8.x", "11.1.x"]
         pybind: ["v2.6.0", "v2.9.2"]
 
     steps:

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -1,12 +1,12 @@
 include(FetchContent)
 
-SET(DEFAULT_ARMA_VERSION 11.0.x)
+SET(DEFAULT_ARMA_VERSION 11.1.x)
 IF (NOT USE_ARMA_VERSION)
     MESSAGE(STATUS "carma: Setting Armadillo version to 'v${DEFAULT_ARMA_VERSION}' as none was specified.")
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)
     # Set the possible values of build type for cmake-gui
     SET_PROPERTY(CACHE USE_ARMA_VERSION PROPERTY STRINGS
-        "10.6.x" "10.8.x" "11.0.x"
+        "10.6.x" "10.8.x" "11.1.x"
     )
 ENDIF ()
 

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -6,7 +6,7 @@ IF (NOT USE_ARMA_VERSION)
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)
     # Set the possible values of build type for cmake-gui
     SET_PROPERTY(CACHE USE_ARMA_VERSION PROPERTY STRINGS
-        "10.6.x" "10.8.x" "10.11.x"
+        "10.6.x" "10.8.x" "11.0.x"
     )
 ENDIF ()
 


### PR DESCRIPTION
@RUrlus the 11.0.x branch will be deleted on gitlab, so update to 11.1.x which will be a long-lived branch

