### PR TITLE
update to armadillo 12.4.x

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        armadillo: ["10.6.x", "10.8.x", "11.2.x", "11.4.x", "12.2.x"]
+        armadillo: ["10.6.x", "10.8.x", "11.2.x", "11.4.x", "12.4.x"]
         pybind: ["v2.6.0", "v2.10.0"]
 
     steps:

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -6,7 +6,7 @@ IF (NOT USE_ARMA_VERSION)
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)
     # Set the possible values of build type for cmake-gui
     SET_PROPERTY(CACHE USE_ARMA_VERSION PROPERTY STRINGS
-        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.2.x"
+        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x"
     )
 ENDIF ()
 


### PR DESCRIPTION
@RUrlus Update to armadillo 12.4.x

Changes since Armadillo 12.2.x:
- added norm2est() for finding fast estimates of matrix 2-norm (spectral norm)
- added vecnorm() for obtaining the vector norm of each row or column of a matrix
- fix bug in SpMat::shed_cols()
- functions such as .is_finite() and find_nonfinite() will now emit a runtime warning when compiled in fast math mode (gcc and clang: -ffast-math or -Ofast); such compilation mode disables detection of non-finite values