### PR TITLE
add armadillo 12.6.x

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        armadillo: ["10.6.x", "10.8.x", "11.2.x", "11.4.x", "12.4.x"]
+        armadillo: ["10.6.x", "10.8.x", "11.2.x", "11.4.x", "12.4.x" "12.6.x"]
         pybind: ["v2.6.0", "v2.10.0"]
 
     steps:

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -1,12 +1,12 @@
 include(FetchContent)
 
-SET(DEFAULT_ARMA_VERSION 12.0.x)
+SET(DEFAULT_ARMA_VERSION 12.6.x)
 IF (NOT USE_ARMA_VERSION)
     MESSAGE(STATUS "carma: Setting Armadillo version to 'v${DEFAULT_ARMA_VERSION}' as none was specified.")
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)
     # Set the possible values of build type for cmake-gui
     SET_PROPERTY(CACHE USE_ARMA_VERSION PROPERTY STRINGS
-        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x"
+        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x" "12.6.x"
     )
 ENDIF ()
 


### PR DESCRIPTION
@RUrlus Add armadillo 12.6.x branch and use it as default

Changes since Armadillo 12.4.x:
- added diags() and spdiags() for generating band matrices from set of vectors
- faster multiplication of dense vectors by sparse matrices (and vice versa)
- faster eigs_sym(), eigs_gen(), svds()
- faster conv() and conv2() when using OpenMP
- use thread-safe Mersenne Twister as the default RNG on all platforms
- use unique RNG seed for each thread within multi-threaded execution (such as OpenMP)
