### PR TITLE
add armadillo 12.8.x

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,8 +35,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        armadillo: ["10.6.x", "10.8.x", "11.2.x", "11.4.x", "12.4.x", "12.6.x", "12.8.x"]
-        pybind: ["v2.6.0", "v2.10.0"]
+        armadillo: ["10.8.x", "11.4.x", "12.4.x", "12.6.x", "12.8.x"]
+        pybind: ["v2.10.4", "v2.11.1"]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        armadillo: ["10.6.x", "10.8.x", "11.2.x", "11.4.x", "12.4.x", "12.6.x"]
+        armadillo: ["10.6.x", "10.8.x", "11.2.x", "11.4.x", "12.4.x", "12.6.x", "12.8.x"]
         pybind: ["v2.6.0", "v2.10.0"]
 
     steps:

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -6,7 +6,7 @@ IF (NOT USE_ARMA_VERSION)
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)
     # Set the possible values of build type for cmake-gui
     SET_PROPERTY(CACHE USE_ARMA_VERSION PROPERTY STRINGS
-        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x" "12.6.x"
+        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x" "12.6.x" "12.8.x"
     )
 ENDIF ()
 

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -1,6 +1,6 @@
 include(FetchContent)
 
-SET(DEFAULT_ARMA_VERSION 12.6.x)
+SET(DEFAULT_ARMA_VERSION 12.8.x)
 IF (NOT USE_ARMA_VERSION)
     MESSAGE(STATUS "carma: Setting Armadillo version to 'v${DEFAULT_ARMA_VERSION}' as none was specified.")
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)

--- a/cmake/GetPybind11.cmake
+++ b/cmake/GetPybind11.cmake
@@ -1,12 +1,12 @@
 include(FetchContent)
 
-SET(DEFAULT_PYBIND11_VERSION v2.9.2)
+SET(DEFAULT_PYBIND11_VERSION v2.11.1)
 IF (NOT USE_PYBIND11_VERSION)
-    MESSAGE(STATUS "carma: Setting Pybind11 version to '${DEFAULT_PYBIND11_VERSION}' as none was specified.")
-    SET(USE_PYBIND11_VERSION "${DEFAULT_PYBIND11_VERSION}" CACHE STRING "Choose the version of Pybind11." FORCE)
+  MESSAGE(STATUS "carma: Setting Pybind11 version to '${DEFAULT_PYBIND11_VERSION}' as none was specified.")
+  SET(USE_PYBIND11_VERSION "${DEFAULT_PYBIND11_VERSION}" CACHE STRING "Choose the version of Pybind11." FORCE)
   # Set the possible values of build type for cmake-gui
   SET_PROPERTY(CACHE USE_PYBIND11_VERSION PROPERTY STRINGS
-    "v2.6.0" "v2.6.1" "v2.6.2" "v2.7.1" "v2.8.1" "v2.9.0" "v2.9.1" "v2.9.2"
+    "v2.6.2" "v2.7.1" "v2.8.1" "v2.9.0" "v2.9.1" "v2.9.2" "v2.10.4" "v2.11.1"
 )
 ENDIF ()
 

--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -11,7 +11,7 @@ SET(MODNAME "integration_test_carma")
 # -- EXTERNAL
 INCLUDE(FetchContent)
 
-SET(USE_PYBIND11_VERSION "v2.6.2")
+SET(USE_PYBIND11_VERSION v2.11.1)
 
 # Pybind11
 FetchContent_Declare(
@@ -25,14 +25,14 @@ FetchContent_GetProperties(Pybind11Repo)
 
 STRING(TOLOWER "Pybind11Repo" lcName)
 IF (NOT ${lcName}_POPULATED)
-  MESSAGE(STATUS "carma: collecting Pybind11 ${USE_PYBIND11_VERSION}")
-  # Fetch the content using previously declared details
-  FetchContent_Populate(Pybind11Repo)
+    MESSAGE(STATUS "carma: collecting Pybind11 ${USE_PYBIND11_VERSION}")
+    # Fetch the content using previously declared details
+    FetchContent_Populate(Pybind11Repo)
 ENDIF ()
 
 ADD_SUBDIRECTORY(extern/pybind11)
 
-SET(USE_ARMA_VERSION 10.6.x)
+SET(USE_ARMA_VERSION 12.8.x)
 FetchContent_Declare(
   CarmaArmadillo
   GIT_REPOSITORY https://gitlab.com/conradsnicta/armadillo-code.git


### PR DESCRIPTION
@RUrlus Add armadillo 12.8.x branch and use it as default

Changes since Armadillo 12.6.x:
- workaround in `norm()` for yet another bug in macOS accelerate framework
- faster detection of symmetric expressions by `pinv()` and `rank()`
- expanded `shift()` to handle sparse matrices
- expanded `conv_to` for more flexible conversions between sparse and dense matrices
- added `cbrt()`
- more compact representation of integers when saving matrices in CSV format
