### PR TITLE
add armadillo 14.4.x

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        armadillo: ["10.8.x", "11.4.x", "12.4.x", "12.6.x", "12.8.x"]
+        armadillo: ["10.8.x", "11.4.x", "12.4.x", "12.6.x", "12.8.x", "14.4.x"]
         pybind: ["v2.12.0"]
 
     steps:

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -1,12 +1,12 @@
 include(FetchContent)
 
-SET(DEFAULT_ARMA_VERSION 12.8.x)
+SET(DEFAULT_ARMA_VERSION 14.4.x)
 IF (NOT USE_ARMA_VERSION)
     MESSAGE(STATUS "carma: Setting Armadillo version to 'v${DEFAULT_ARMA_VERSION}' as none was specified.")
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)
     # Set the possible values of build type for cmake-gui
     SET_PROPERTY(CACHE USE_ARMA_VERSION PROPERTY STRINGS
-        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x" "12.6.x" "12.8.x"
+        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x" "12.6.x" "12.8.x" "14.4.x"
     )
 ENDIF ()
 

--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -32,7 +32,7 @@ ENDIF ()
 
 ADD_SUBDIRECTORY(extern/pybind11)
 
-SET(USE_ARMA_VERSION 12.8.x)
+SET(USE_ARMA_VERSION 14.4.x)
 FetchContent_Declare(
   CarmaArmadillo
   GIT_REPOSITORY https://gitlab.com/conradsnicta/armadillo-code.git


### PR DESCRIPTION
@RUrlus This PR adds and changes the default to Armadillo 14.4.x.

14.4.x has speedups and new features compared to 12.8.x.  
Changelog: https://arma.sourceforge.net/docs.html#changelog

