### PR TITLE
add armadillo 15.2.x

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        armadillo: ["10.8.x", "11.4.x", "12.4.x", "12.6.x", "12.8.x", "14.4.x", "15.0.x"]
+        armadillo: ["10.8.x", "11.4.x", "12.4.x", "12.6.x", "12.8.x", "14.4.x", "15.0.x", "15.2.x"]
         pybind: ["v2.12.0"]
 
     steps:

--- a/cmake/GetArmadillo.cmake
+++ b/cmake/GetArmadillo.cmake
@@ -1,12 +1,12 @@
 include(FetchContent)
 
-SET(DEFAULT_ARMA_VERSION 15.0.x)
+SET(DEFAULT_ARMA_VERSION 15.2.x)
 IF (NOT USE_ARMA_VERSION)
     MESSAGE(STATUS "carma: Setting Armadillo version to 'v${DEFAULT_ARMA_VERSION}' as none was specified.")
     SET(USE_ARMA_VERSION "${DEFAULT_ARMA_VERSION}" CACHE STRING "Choose the version of Armadillo." FORCE)
     # Set the possible values of build type for cmake-gui
     SET_PROPERTY(CACHE USE_ARMA_VERSION PROPERTY STRINGS
-        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x" "12.6.x" "12.8.x" "14.4.x" "15.0.x"
+        "10.6.x" "10.8.x" "11.2.x" "11.4.x" "12.4.x" "12.6.x" "12.8.x" "14.4.x" "15.0.x" "15.2.x"
     )
 ENDIF ()
 

--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -32,7 +32,7 @@ ENDIF ()
 
 ADD_SUBDIRECTORY(extern/pybind11)
 
-SET(USE_ARMA_VERSION 15.0.x)
+SET(USE_ARMA_VERSION 15.2.x)
 FetchContent_Declare(
   CarmaArmadillo
   GIT_REPOSITORY https://gitlab.com/conradsnicta/armadillo-code.git


### PR DESCRIPTION
@RUrlus Update default to Armadillo 15.2.x.

Changes in Armadillo 15.2 since 15.0:
* workarounds for bugs in GCC and Clang sanitisers (ASAN false positives)
* faster .resize() for vectors
* faster repcube()
* faster handling of submatrices with one row
* faster handling of blank sparse matrices
* improved reproducibility of random number generation when using OpenMP
* added rande() for generating matrices with elements from exponential distributions
* shift() has been deprecated in favour of circshift(), for consistency with Matlab/Octave
* reworked detection of aliasing, leading to more efficient compiled code
